### PR TITLE
Improve code foreground color for new dark theme

### DIFF
--- a/src/templates/assets/stylesheets/palette/_scheme.scss
+++ b/src/templates/assets/stylesheets/palette/_scheme.scss
@@ -44,7 +44,7 @@
     --md-default-bg-color--lightest:   hsla(var(--md-hue), 15%, 14%, 0.07);
 
     // Code color shades
-    --md-code-fg-color:                hsla(var(--md-hue), 18%, 86%, 1);
+    --md-code-fg-color:                hsla(var(--md-hue), 15%, 90%, 0.75);
     --md-code-bg-color:                hsla(var(--md-hue), 15%, 17%, 1);
 
     // Code highlighting color shades


### PR DESCRIPTION
Before: The code still looks a little shiny.
<img width="782" alt="image" src="https://github.com/krahets/mkdocs-material/assets/26993056/6133adab-d3a2-411c-88d3-2ab9dbcfa61e">

After: More consistent visualization of body text and code.
<img width="782" alt="image" src="https://github.com/krahets/mkdocs-material/assets/26993056/081d8af6-dd1c-48cb-b0bc-0a1039890903">
